### PR TITLE
Fix for error since 2021.12b0

### DIFF
--- a/custom_components/brandriskute/manifest.json
+++ b/custom_components/brandriskute/manifest.json
@@ -5,7 +5,7 @@
   "dependencies": [],
   "codeowners": ["@Sha-Darim"],
   "issue_tracker": "https://github.com/Sha-Darim/brandriskute/issues",
-  "version": "v1.1.2",
+  "version": "v1.1.3",
   "requirements": [],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/brandriskute/sensor.py
+++ b/custom_components/brandriskute/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.const import (
     CONF_LATITUDE, CONF_LONGITUDE, CONF_NAME)
 from homeassistant.util import Throttle
 
-__version__ = '1.1.1'
+__version__ = '1.1.3'
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/brandriskute/sensor.py
+++ b/custom_components/brandriskute/sensor.py
@@ -93,7 +93,7 @@ class BrandriskSensor(Entity):
         return self._api.state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         data = {}
         keys = list(self._api.current.keys())
@@ -139,7 +139,7 @@ class BrandriskForecastSensor(Entity):
         return self._api.state
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
 
         return {
@@ -179,7 +179,7 @@ class BrandriskProhibitionSensor(Entity):
         return self._api.prohibition['status']
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the state attributes of the sensor."""
         data = {}
         keys = list(self._api.prohibition.keys())


### PR DESCRIPTION
Changes device_state_attributes to extra_state_attributes as per 2021.12b0 deprecation in Home Assistant
Also bumped version to 1.1.3 and fixed error in __version__ label inside sensor.py (was not synced)